### PR TITLE
Merge changes from v2.7.0-next.1 into main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+# [2.7.0-next.1](https://github.com/Nerdware-LLC/ddb-single-table/compare/v2.6.3...v2.7.0-next.1) (2024-06-10)
+
+
+### Features
+
+* add 'transformValues' and 'validate' ioActions to processKeyArgs ([5c0d2e5](https://github.com/Nerdware-LLC/ddb-single-table/commit/5c0d2e5bc4dc631c32cf73cc95aea24ef52232b7))
+
 ## [2.6.3](https://github.com/Nerdware-LLC/ddb-single-table/compare/v2.6.2...v2.6.3) (2024-06-10)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nerdware/ddb-single-table",
-  "version": "2.6.3",
+  "version": "2.7.0-next.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nerdware/ddb-single-table",
-      "version": "2.6.3",
+      "version": "2.7.0-next.1",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.572.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nerdware/ddb-single-table",
-  "version": "2.6.3",
+  "version": "2.7.0-next.1",
   "description": "A schema-based DynamoDB modeling tool, high-level API, and type-generator built for single-table designs.",
   "author": {
     "name": "Trevor Anderson",

--- a/src/Model/Model.ts
+++ b/src/Model/Model.ts
@@ -831,9 +831,10 @@ export class Model<
       [
         ioActions.aliasMapping,
         ioActions.setDefaults,
+        ioActions.transformValues,
         ioActions.typeChecking,
-        ioActions.convertJsTypes, // FIXME what other IO-Actions should be applied to keys?
-        //                           FIXME WHY NOT attr validation?
+        ioActions.validate,
+        ioActions.convertJsTypes,
         ioActions.checkRequired,
       ],
       {


### PR DESCRIPTION
Merge changes from [v2.7.0-next.1][src-tag] into [main][main-branch].

Details regarding the included changes are provided in the [release notes][src-tag] and the [CHANGELOG][main-changelog].

[src-tag]: https://github.com/Nerdware-LLC/ddb-single-table/releases/tag/v2.7.0-next.1

<!-- DEFAULT DEST: main branch -->

[main-branch]: https://github.com/Nerdware-LLC/ddb-single-table/tree/main
[main-changelog]: https://github.com/Nerdware-LLC/ddb-single-table/tree/main/CHANGELOG.md
